### PR TITLE
Fix cmesh readmshfile bug with orientation

### DIFF
--- a/src/t8_cmesh/t8_cmesh_readmshfile.cxx
+++ b/src/t8_cmesh/t8_cmesh_readmshfile.cxx
@@ -1480,8 +1480,8 @@ t8_msh_file_face_orientation (t8_msh_file_face_t * Face_a,
   }
   else {
     /* both classes are the same, thus
-     * the face with the smaller tree id is the smaller one */
-    if (Face_a->ltree_id < Face_b->ltree_id) {
+     * the face with the smaller face id is the smaller one */
+    if (Face_a->face_number < Face_b->face_number) {
       smaller_Face = Face_a;
       bigger_Face = Face_b;
       bigger_class =


### PR DESCRIPTION
For a face-to-face connection one face is declared
as the 'smaller face'. This info is used when the
orientation is computed.
For cmesh read msh file the computation of the smaller face
was wrong.
If both eclasses of the trees are the same then the 'smaller face'
is the face with smaller face_id.
Instead in readmshfile the face of the tree with smaller tree id
was used.

We fixed this behaviour.